### PR TITLE
fix: enhance document processing in folder2knowledge.js to return content in chunks which was causing error: Error processing directory ./examples/documents: TypeError: fileChunks is not iterable (cannot read property undefined)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "characterfile",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "characterfile",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.2",

--- a/scripts/folder2knowledge.js
+++ b/scripts/folder2knowledge.js
@@ -88,8 +88,18 @@ const processDocument = async (filePath) => {
   } else {
     content = await fs.readFile(filePath, 'utf8');
   }
-  
-  return content;
+
+  // Split content into chunks
+  const chunkSize = 1000; // Example chunk size
+  const chunks = [];
+  for (let i = 0; i < content.length; i += chunkSize) {
+    chunks.push(content.substring(i, i + chunkSize));
+  }
+
+  return {
+    document: content,
+    chunks: chunks
+  };
 };
 
 // Asynchronous function to recursively find files and process them


### PR DESCRIPTION
I was getting the following error 

Error processing directory ./examples/documents: TypeError: fileChunks is not iterable (cannot read property undefined)

Returned file chunks which was expected 

Successful run / file output: 
[StaffEngineer.knowledge.character.json](https://github.com/user-attachments/files/18256560/StaffEngineer.knowledge.character.json)


<img width="819" alt="Screenshot 2024-12-26 at 4 57 05 PM" src="https://github.com/user-attachments/assets/13b09252-0f98-4b91-8fc7-b369fedc7a56" />
