### PR TITLE
docs: Fixed typo in the JavaScript Validation Example title

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Read the example character file and validate it against the JSON schema
 Read the example character file and print the contents
 [examples/example.mjs](examples/example.mjs)
 
-### JavScript Validation Example
+### JavaScript Validation Example
 Read the example character file and validate it against the JSON schema
 [examples/validate.mjs](examples/validate.mjs)
 


### PR DESCRIPTION
Hello, team!

I noticed a typo in the title "JavScript Validation Example."
It was missing the letter "a" in "JavaScript." I’ve corrected it to "**JavaScript Validation Example**."